### PR TITLE
Feat/#9 게시글 카드 스켈레톤 구현 - 자유게시판, 질문게시판

### DIFF
--- a/src/components/Common/CommunityPostCard.js
+++ b/src/components/Common/CommunityPostCard.js
@@ -1,3 +1,4 @@
+import styled from "styled-components";
 import {
   PostCardWrapper,
   InnerContainer,
@@ -14,7 +15,7 @@ export const CustomBody = styled(Body)`
 
 function CommunityPostCard({ title, content, name, job, count }) {
   return (
-    <PostCardWrapper>
+    <PostCardWrapper width="985px" height="232px">
       <InnerContainer>
         <Thumbnail />
         <CustomBody>

--- a/src/components/Common/CommunityPostCard.js
+++ b/src/components/Common/CommunityPostCard.js
@@ -1,0 +1,58 @@
+import styled from "styled-components";
+import {
+  Interaction,
+  ArrowButton,
+  PostProfile,
+  PostContent,
+} from "./PostCardComponents";
+
+const PostCardWrapper = styled.div`
+  display: flex;
+  border: 1px solid;
+  width: 985px;
+  height: 232px;
+`;
+
+const InnerContainer = styled.div`
+  display: flex;
+  flex-grow: 1;
+  margin: 10px;
+`;
+
+const Thumbnail = styled.div`
+  flex-grow: 1;
+  border: 1px solid;
+`;
+
+const Body = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex-grow: 2;
+  padding: 10px 0 10px 10px;
+`;
+
+const PostActions = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+`;
+
+function CommunityPostCard({ title, content, name, job, count }) {
+  return (
+    <PostCardWrapper>
+      <InnerContainer>
+        <Thumbnail />
+        <Body>
+          <PostActions>
+            <PostProfile name={name} job={job} />
+            <Interaction count={count} />
+          </PostActions>
+          <PostContent title={title} content={content} />
+          <ArrowButton />
+        </Body>
+      </InnerContainer>
+    </PostCardWrapper>
+  );
+}
+
+export default CommunityPostCard;

--- a/src/components/Common/CommunityPostCard.js
+++ b/src/components/Common/CommunityPostCard.js
@@ -1,40 +1,15 @@
-import styled from "styled-components";
 import {
-  Interaction,
-  ArrowButton,
-  PostProfile,
-  PostContent,
-} from "./PostCardComponents";
+  PostCardWrapper,
+  InnerContainer,
+  Body,
+  PostActions,
+} from "./PostCardWrapper";
+import { PostProfile, PostContent, Thumbnail } from "./PostCardComponents";
+import { Interaction, ArrowButton } from "./Interactions";
 
-const PostCardWrapper = styled.div`
-  display: flex;
-  border: 1px solid;
-  width: 985px;
-  height: 232px;
-`;
-
-const InnerContainer = styled.div`
-  display: flex;
-  flex-grow: 1;
-  margin: 10px;
-`;
-
-const Thumbnail = styled.div`
-  flex-grow: 1;
-  border: 1px solid;
-`;
-
-const Body = styled.div`
-  display: flex;
-  flex-direction: column;
+export const CustomBody = styled(Body)`
   flex-grow: 2;
   padding: 10px 0 10px 10px;
-`;
-
-const PostActions = styled.div`
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-end;
 `;
 
 function CommunityPostCard({ title, content, name, job, count }) {
@@ -42,14 +17,14 @@ function CommunityPostCard({ title, content, name, job, count }) {
     <PostCardWrapper>
       <InnerContainer>
         <Thumbnail />
-        <Body>
+        <CustomBody>
           <PostActions>
             <PostProfile name={name} job={job} />
             <Interaction count={count} />
           </PostActions>
           <PostContent title={title} content={content} />
           <ArrowButton />
-        </Body>
+        </CustomBody>
       </InnerContainer>
     </PostCardWrapper>
   );

--- a/src/components/Common/Interactions.js
+++ b/src/components/Common/Interactions.js
@@ -1,0 +1,55 @@
+import eyeIcon from "../../assets/images/eye.png";
+import heartIcon from "../../assets/images/heart.png";
+import commentIcon from "../../assets/images/comment.png";
+
+const InteractionsWrapper = styled.div`
+  display: flex;
+`;
+
+const InteractionItemWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  margin-right: 8px;
+`;
+
+const Icon = styled.img`
+  width: 16px;
+  height: 16px;
+  margin-right: 4px;
+`;
+
+const IconText = styled.span`
+  font-size: 13px;
+`;
+
+const DefaultArrow = styled.button`
+  width: 40px;
+  height: 24px;
+  border-radius: 16px 0 0 16px;
+`;
+
+const MirroredArrow = styled(DefaultArrow)`
+  transform: scaleX(-1);
+`;
+
+const InteractionItem = ({ icon, count }) => (
+  <InteractionItemWrapper>
+    <Icon src={icon} />
+    <IconText>{count}</IconText>
+  </InteractionItemWrapper>
+);
+
+export const Interaction = ({ count }) => (
+  <InteractionsWrapper>
+    <InteractionItem icon={eyeIcon} count={count.view} />
+    <InteractionItem icon={heartIcon} count={count.like} />
+    <InteractionItem icon={commentIcon} count={count.comment} />
+  </InteractionsWrapper>
+);
+
+export const ArrowButton = () => (
+  <div>
+    <DefaultArrow></DefaultArrow>
+    <MirroredArrow></MirroredArrow>
+  </div>
+);

--- a/src/components/Common/Interactions.js
+++ b/src/components/Common/Interactions.js
@@ -1,3 +1,4 @@
+import styled from "styled-components";
 import eyeIcon from "../../assets/images/eye.png";
 import heartIcon from "../../assets/images/heart.png";
 import commentIcon from "../../assets/images/comment.png";

--- a/src/components/Common/PostCardComponents.js
+++ b/src/components/Common/PostCardComponents.js
@@ -1,37 +1,4 @@
 import styled from "styled-components";
-import eyeIcon from "../../assets/images/eye.png";
-import heartIcon from "../../assets/images/heart.png";
-import commentIcon from "../../assets/images/comment.png";
-
-const InteractionsWrapper = styled.div`
-  display: flex;
-`;
-
-const InteractionItemWrapper = styled.div`
-  display: flex;
-  align-items: center;
-  margin-right: 8px;
-`;
-
-const Icon = styled.img`
-  width: 16px;
-  height: 16px;
-  margin-right: 4px;
-`;
-
-const IconText = styled.span`
-  font-size: 13px;
-`;
-
-const DefaultArrow = styled.button`
-  width: 40px;
-  height: 24px;
-  border-radius: 16px 0 0 16px;
-`;
-
-const MirroredArrow = styled(DefaultArrow)`
-  transform: scaleX(-1);
-`;
 
 const ContentContainer = styled.div`
   flex-grow: 1;
@@ -40,6 +7,11 @@ const ContentContainer = styled.div`
   border-bottom: 1px solid;
   padding: 10px 0;
   margin: 10px 0 10px 0;
+`;
+
+const ThumbnailWrapper = styled.div`
+  flex-grow: 1;
+  border: 1px solid;
 `;
 
 const ProfileWrapper = styled.div`
@@ -61,28 +33,6 @@ const ProfileInfo = styled.div`
   flex-direction: column;
 `;
 
-const InteractionItem = ({ icon, count }) => (
-  <InteractionItemWrapper>
-    <Icon src={icon} />
-    <IconText>{count}</IconText>
-  </InteractionItemWrapper>
-);
-
-export const Interaction = ({ count }) => (
-  <InteractionsWrapper>
-    <InteractionItem icon={eyeIcon} count={count.view} />
-    <InteractionItem icon={heartIcon} count={count.like} />
-    <InteractionItem icon={commentIcon} count={count.comment} />
-  </InteractionsWrapper>
-);
-
-export const ArrowButton = () => (
-  <div>
-    <DefaultArrow></DefaultArrow>
-    <MirroredArrow></MirroredArrow>
-  </div>
-);
-
 export const PostProfile = ({ name, job }) => (
   <ProfileWrapper>
     <ProfileImage />
@@ -99,3 +49,5 @@ export const PostContent = ({ title, content }) => (
     <p>{content}</p>
   </ContentContainer>
 );
+
+export const Thumbnail = () => <ThumbnailWrapper></ThumbnailWrapper>;

--- a/src/components/Common/PostCardComponents.js
+++ b/src/components/Common/PostCardComponents.js
@@ -34,17 +34,17 @@ const MirroredArrow = styled(DefaultArrow)`
 `;
 
 const ContentContainer = styled.div`
-  width: 100%;
+  flex-grow: 1;
   height: 120px;
   border-top: 1px solid;
   border-bottom: 1px solid;
   padding: 10px 0;
+  margin: 10px 0 10px 0;
 `;
 
 const ProfileWrapper = styled.div`
   display: flex;
   width: 100%;
-  margin-top: 10px;
 `;
 
 const ProfileImage = styled.div`

--- a/src/components/Common/PostCardWrapper.js
+++ b/src/components/Common/PostCardWrapper.js
@@ -1,0 +1,27 @@
+import styled from "styled-components";
+
+export const PostCardWrapper = styled.div`
+  display: flex;
+  border: 1px solid;
+  width: ${({ width }) => width || "100%"};
+  height: ${({ height }) => height || "100%"};
+`;
+
+export const InnerContainer = styled.div`
+  display: flex;
+  flex-direction: ${({ direction }) => direction || "column"};
+  flex-grow: 1;
+  margin: 10px;
+`;
+
+export const Body = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding: 10px 10px 0 10px;
+`;
+
+export const PostActions = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+`;

--- a/src/components/Common/PostCardWrapper.js
+++ b/src/components/Common/PostCardWrapper.js
@@ -9,7 +9,7 @@ export const PostCardWrapper = styled.div`
 
 export const InnerContainer = styled.div`
   display: flex;
-  flex-direction: ${({ direction }) => direction || "column"};
+  flex-direction: ${({ direction }) => direction || "row"};
   flex-grow: 1;
   margin: 10px;
 `;

--- a/src/components/Common/ProjectPostCard.js
+++ b/src/components/Common/ProjectPostCard.js
@@ -1,37 +1,13 @@
-import styled from "styled-components";
 import {
-  Interaction,
-  ArrowButton,
-  PostProfile,
-  PostContent,
-} from "./PostCardComponents";
+  PostCardWrapper,
+  InnerContainer,
+  Body,
+  PostActions,
+} from "./PostCardWrapper";
+import { PostProfile, PostContent, Thumbnail } from "./PostCardComponents";
+import { Interaction, ArrowButton } from "./Interactions";
 
-const PostCardWrapper = styled.div`
-  display: flex;
-  border: 1px solid;
-  width: 280px;
-  height: 440px;
-`;
-
-const InnerContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  flex-grow: 1;
-  margin: 10px;
-`;
-
-const Thumbnail = styled.div`
-  flex-grow: 1;
-  border: 1px solid;
-`;
-
-const Body = styled.div`
-  padding: 10px 10px 0;
-`;
-
-const PostActions = styled.div`
-  display: flex;
-  justify-content: space-between;
+const CustomPostActions = styled(PostActions)`
   align-items: center;
   margin: 10px 0;
 `;
@@ -42,10 +18,10 @@ function ProjectPostCard({ title, content, name, job, count }) {
       <InnerContainer>
         <Thumbnail />
         <Body>
-          <PostActions>
+          <CustomPostActions>
             <Interaction count={count} />
             <ArrowButton />
-          </PostActions>
+          </CustomPostActions>
           <PostContent title={title} content={content} />
           <PostProfile name={name} job={job} />
         </Body>

--- a/src/components/Common/ProjectPostCard.js
+++ b/src/components/Common/ProjectPostCard.js
@@ -1,3 +1,4 @@
+import styled from "styled-components";
 import {
   PostCardWrapper,
   InnerContainer,
@@ -9,13 +10,13 @@ import { Interaction, ArrowButton } from "./Interactions";
 
 const CustomPostActions = styled(PostActions)`
   align-items: center;
-  margin: 10px 0;
+  margin-top: 10px;
 `;
 
 function ProjectPostCard({ title, content, name, job, count }) {
   return (
-    <PostCardWrapper>
-      <InnerContainer>
+    <PostCardWrapper width="280px" height="440px">
+      <InnerContainer direction="column">
         <Thumbnail />
         <Body>
           <CustomPostActions>

--- a/src/pages/FreeBoard.js
+++ b/src/pages/FreeBoard.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
-import ProjectPostCard from "../components/Common/ProjectPostCard";
 import { fetchPostItems } from "../services/api";
+import CommunityPostCard from "../components/Common/CommunityPostCard";
 
 function FreeBoard() {
   const [postItems, setPostItems] = useState([]);
@@ -14,7 +14,7 @@ function FreeBoard() {
   return (
     <>
       {postItems.map((post) => (
-        <ProjectPostCard
+        <CommunityPostCard
           key={post.id}
           title={post.title}
           content={post.content}

--- a/src/pages/ProjectBoard.js
+++ b/src/pages/ProjectBoard.js
@@ -1,9 +1,28 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
+import ProjectPostCard from "../components/Common/ProjectPostCard";
+import { fetchPostItems } from "../services/api";
 
 function ProjectBoard() {
+  const [postItems, setPostItems] = useState([]);
+
+  useEffect(() => {
+    fetchPostItems()
+      .then((postItems) => setPostItems(postItems))
+      .catch((err) => console.log(err));
+  });
+
   return (
     <>
-      <div>ProjectBoard</div>
+      {postItems.map((post) => (
+        <ProjectPostCard
+          key={post.id}
+          title={post.title}
+          content={post.content}
+          name={post.name}
+          job={post.job}
+          count={post.count}
+        />
+      ))}
     </>
   );
 }


### PR DESCRIPTION
- 제목 : feat(#9): 게시글 카드 스켈레톤 구현 - 자유게시판, 질문게시판

## 🔘Part

- [x] FE

<br/>

## 🔎 작업 내용

- 게시글 카드 기본 구조 설정
- API 호출 구조 재사용
- PostCardComponents 재사용을 위해 css 변경
- PostCardComponents 종류에 따른 파일 분리
- 각 게시글 카드에 사용되는 styled components 재사용 가능하도록 변경

  <br/>

## 이미지 첨부(선택)

<img src="https://github.com/user-attachments/assets/641fe024-2dbd-434b-99fd-89825ffc35b1" width="50%" height="50%"/>

<br/>

## 💬리뷰 요구사항(선택)

코드 리뷰 부탁드립니다!
