### PR TITLE
Feat/#59: 닉네임, 이메일 중복검사 api 구현

### DIFF
--- a/src/components/Modal/SignUpModal/SignUpModal.jsx
+++ b/src/components/Modal/SignUpModal/SignUpModal.jsx
@@ -3,6 +3,7 @@ import profileIcon from "../../assets/images/profileIcon.png";
 import { signup } from "../../../services/api";
 import { Btn, Container, Divider, Form } from "../Modal.style";
 import { FormInputField } from "../FormInputField";
+import { ProfileImgDiv, SignUpHeader } from "./SignUpModal.style";
 
 export default function SignUpModal() {
   const [profileImg, setProfileImg] = useState(null);

--- a/src/components/Modal/SignUpModal/SignUpModal.jsx
+++ b/src/components/Modal/SignUpModal/SignUpModal.jsx
@@ -1,9 +1,13 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import profileIcon from "../../assets/images/profileIcon.png";
 import { signup } from "../../../services/api";
 import { Btn, Container, Divider, Form } from "../Modal.style";
 import { FormInputField } from "../FormInputField";
 import { ProfileImgDiv, SignUpHeader } from "./SignUpModal.style";
+import {
+  checkDuplicatedEmail,
+  checkDuplicatedNickname,
+} from "../../../services/authApi";
 
 export default function SignUpModal() {
   const [profileImg, setProfileImg] = useState(null);
@@ -12,6 +16,8 @@ export default function SignUpModal() {
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
   const [phoneNum, setPhoneNum] = useState("");
+  const [isNameValid, setIsNameValid] = useState(null);
+  const [isEmailValid, setIsEmailValid] = useState(null);
 
   async function handleSignUp(e) {
     e.preventDefault();
@@ -41,6 +47,36 @@ export default function SignUpModal() {
     }
   };
 
+  useEffect(() => {
+    const handleCheckNickname = async (e) => {
+      if (name.length > 0) {
+        try {
+          const isValid = await checkDuplicatedNickname(name);
+          setIsNameValid(isValid);
+        } catch (error) {
+          console.log("checking nickname error", error);
+          setIsNameValid(false);
+        }
+      }
+    };
+    handleCheckNickname();
+  }, [name]);
+
+  useEffect(() => {
+    const handleCheckEmail = async (e) => {
+      if (email.length > 0) {
+        try {
+          const isValid = await checkDuplicatedEmail(email);
+          setIsEmailValid(isValid);
+        } catch (error) {
+          console.log("checking email error", error);
+          setIsEmailValid(false);
+        }
+      }
+    };
+    handleCheckEmail();
+  }, [email]);
+
   return (
     <Container width="530px" height="918px">
       <div>
@@ -58,8 +94,26 @@ export default function SignUpModal() {
               <input type="file" onChange={handleImageChange} />
             </div>
           </ProfileImgDiv>
-          <FormInputField label={"닉네임"} type={"text"} value={name} />
-          <FormInputField label={"이메일"} type={"email"} value={email} />
+          <FormInputField
+            label={"닉네임"}
+            type={"text"}
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+          />
+          {isNameValid === false && (
+            <p style={{ color: "red" }}>이미 사용 중인 닉네임입니다.</p>
+          )}
+          <FormInputField
+            label={"이메일"}
+            type={"email"}
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+          />
+          {isEmailValid === false && (
+            <p style={{ color: "red" }}>이미 사용 중인 이메일입니다.</p>
+          )}
           <FormInputField
             label={"비밀번호"}
             type={"password"}
@@ -70,7 +124,12 @@ export default function SignUpModal() {
             type={"password"}
             value={confirmPassword}
           />
-          <FormInputField label={"휴대폰 번호"} type={"tel"} value={phoneNum} />
+          <FormInputField
+            label={"휴대폰 번호"}
+            type={"tel"}
+            value={phoneNum}
+            required
+          />
           <Divider />
           <Btn type="submit">계정 생성하기</Btn>
         </Form>

--- a/src/services/authApi.js
+++ b/src/services/authApi.js
@@ -1,0 +1,29 @@
+import axios from "axios";
+
+const API_URL = "http://localhost:8080";
+
+// 닉네임 중복검사
+const checkDuplicatedNickname = async (name) => {
+  try {
+    const res = await axios.get(`${API_URL}/members/validate/nickname`, {
+      params: { nickname: name },
+    });
+    return res.data;
+  } catch (error) {
+    console.log("checking nickname error", error);
+    throw error;
+  }
+};
+
+// 이메일 중복검사
+const checkDuplicatedEmail = async (email) => {
+  try {
+    const res = await axios.get(`${API_URL}/members/validate/email`, {
+      params: { email },
+    });
+    return res.data;
+  } catch (error) {
+    console.log("checking email error", error);
+    throw error;
+  }
+};

--- a/src/services/authApi.js
+++ b/src/services/authApi.js
@@ -2,7 +2,6 @@ import axios from "axios";
 
 const API_URL = "http://localhost:8080";
 
-// 닉네임 중복검사
 const checkDuplicatedNickname = async (name) => {
   try {
     const res = await axios.get(`${API_URL}/members/validate/nickname`, {
@@ -15,7 +14,6 @@ const checkDuplicatedNickname = async (name) => {
   }
 };
 
-// 이메일 중복검사
 const checkDuplicatedEmail = async (email) => {
   try {
     const res = await axios.get(`${API_URL}/members/validate/email`, {
@@ -27,3 +25,5 @@ const checkDuplicatedEmail = async (email) => {
     throw error;
   }
 };
+
+export { checkDuplicatedNickname, checkDuplicatedEmail };


### PR DESCRIPTION
## 🔘Part

- [x] FE

<br/>

## 🔎 작업 내용

- 회원가입 모달에 스타일 파일 import 시킴
- 닉네임, 이메일 중복검사 api 구현
- 회원가입 모달에서 중복검사 기능 구현

> ❗아직 모달을 생성하지 않아서 화면 상에서 확인하려면 모달 구현 후에 가능할 것 같아요. 일단 코드로 확인해주세요

  <br/>

## 💬리뷰 요구사항(선택)

> 코드 확인하고 수정사항 리뷰 달아주세요!

### 이슈 닫기

Closes #59
